### PR TITLE
Support template script tags

### DIFF
--- a/grammars/blade.cson
+++ b/grammars/blade.cson
@@ -1,5 +1,5 @@
 'name': 'Blade'
-'scopeName': 'text.html.php'
+'scopeName': 'text.html.php.blade'
 'comment': 'Syntax highlighting for Laravel Blade templates.'
 'fileTypes': [
   'blade.php'
@@ -280,7 +280,7 @@
         'end': '(</)((?i:script))'
         'patterns': [
           {
-            'include': 'text.html.php'
+            'include': 'text.html.php.blade'
           }
         ]
       }


### PR DESCRIPTION
Includes highlighting inside template script tags with types: `text/html` `text/x-handlebars` `text/x-handlebars-template` `text/template`. Those are the most common types that I know.
