### PR TITLE
Remove injection rule

### DIFF
--- a/grammars/blade.cson
+++ b/grammars/blade.cson
@@ -7,15 +7,6 @@
 'firstLineMatch': '^#!.*(?<!-)php[0-9]{0,1}\\b',
 'foldingStartMarker': '\\@\\b(section)\\b(?=(|\\s*|)\\()'
 'foldingStopMarker': '\\)(?!.*\\))'
-'injections':
-  'R:text.html - comment.block':
-    'comment': 'Use R: to ensure this matches after any other injections.'
-    'patterns': [
-      {
-        'match': '<'
-        'name': 'invalid.illegal.bad-angle-bracket.html'
-      }
-    ]
 'patterns': [
   {
     'begin': '\\{\\{--'


### PR DESCRIPTION
This rule is not properly supported by Atom and causes angle brackets to get highlighted weirdly. See https://github.com/atom/language-html/pull/34
