### PR TITLE
Fix the new raw HTML output of Blade in Laravel 5.

### DIFF
--- a/grammars/blade.cson
+++ b/grammars/blade.cson
@@ -37,7 +37,7 @@
     'beginCaptures':
       '0':
         'name': 'support.punctuation.php'
-    'end': '-?\\}?\\!\\!'
+    'end': '-?\\!\\!\\}'
     'endCaptures':
       '0':
         'name': 'support.punctuation.php'


### PR DESCRIPTION
The closed curly bracket wasn't well colorized:
![atom_blade_laravel_5](https://cloud.githubusercontent.com/assets/5038872/6480531/093b536a-c255-11e4-8d99-91e35f95f586.png)