### PR TITLE
Fixed bug where inner '}' or '!' in closing tag were highlighted wrong

### DIFF
--- a/grammars/blade.cson
+++ b/grammars/blade.cson
@@ -25,7 +25,7 @@
           '1':
             'name': 'source.php'
         'contentName': 'source.php'
-        'end': '(})}}'
+        'end': '}}}'
         'name': 'meta.embedded.echo.blade'
         'patterns': [
           {


### PR DESCRIPTION
Perhaps I'm not fully understanding issue https://github.com/jawee/language-blade/issues/21 but this minor change fixes the highlighting issue for `}}` and `!!}` tags.