### PR TITLE
Fixed highlighting issue with ending tags }}, }}}, and !!}

### DIFF
--- a/grammars/blade.cson
+++ b/grammars/blade.cson
@@ -19,13 +19,18 @@
       }
       {
         'begin': '(?<!@){{{'
-        'captures':
+        'beginCaptures':
           '0':
             'name': 'support.punctuation.blade'
           '1':
             'name': 'source.php'
         'contentName': 'source.php'
         'end': '(})}}'
+        'endCaptures':
+          '0':
+            'name': 'support.punctuation.blade'
+          '1':
+            'name': 'source.php.support.punctuation.blade'
         'name': 'meta.embedded.echo.blade'
         'patterns': [
           {
@@ -35,13 +40,18 @@
       }
       {
         'begin': '(?<![@{]){{'
-        'captures':
+        'beginCaptures':
           '0':
             'name': 'support.punctuation.blade'
           '1':
             'name': 'source.php'
         'contentName': 'source.php'
         'end': '(})}'
+        'endCaptures':
+          '0':
+            'name': 'support.punctuation.blade'
+          '1':
+            'name': 'source.php.support.punctuation.blade'
         'name': 'meta.embedded.echo.blade'
         'patterns': [
           {
@@ -51,13 +61,18 @@
       }
       {
         'begin': '(?<!@){!!'
-        'captures':
+        'beginCaptures':
           '0':
             'name': 'support.punctuation.blade'
           '1':
             'name': 'source.php'
         'contentName': 'source.php'
         'end': '(!)!}'
+        'endCaptures':
+          '0':
+            'name': 'support.punctuation.blade'
+          '1':
+            'name': 'source.php.support.punctuation.blade'
         'name': 'meta.embedded.echo.blade'
         'patterns': [
           {


### PR DESCRIPTION
In relation to https://github.com/jawee/language-blade/issues/21. It's still not ideal, because you have to still select the character closest to the actual `source` and apply `source.php` in addition to the normal `support.punctuation.blade.`  Anyway, I figured this could be merged to at least fix the highlighting issue until autocomplete gets updated where this is no longer a problem. 