### PR TITLE
Don't remove comment configuration on deactivate.

### DIFF
--- a/lib/language-blade.coffee
+++ b/lib/language-blade.coffee
@@ -10,7 +10,6 @@ module.exports =
     @changeUseBladeComments = atom.config.observe 'language-blade.useBladeComments', @setBladeComments
 
   deactivate: ->
-    @setBladeComments(false)
     @changeUseBladeComments.dispose()
 
   setBladeComments: (enabled) ->


### PR DESCRIPTION
Deactivate is called when the Atom window closes. So currently, if there are multiple Atom windows open, closing one overrides the Blade comment configuration and all other open windows start using HTML comments even though "Use Blade Comments" is still checked in the package settings UI.