### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/appveyor.yml export-ignore
+/CHANGELOG.md export-ignore
+/README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,4 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /appveyor.yml export-ignore
-/CHANGELOG.md export-ignore
-/README.md export-ignore
+


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, tests, .travis.yml, etc).

Happy Hacktoberfest!