### PR TITLE
Add blade-markdown support

### DIFF
--- a/grammars/blade-markdown.cson
+++ b/grammars/blade-markdown.cson
@@ -1,0 +1,16 @@
+'scopeName': 'source.gfm.blade'
+'name': 'Blade (Markdown)'
+'fileTypes': [
+  'blade.md'
+]
+'patterns': [
+  {
+    'include': 'text.html.php.blade#blade'
+  }
+  {
+    'include': 'text.html.basic'
+  }
+  {
+    'include': 'source.gfm'
+  }
+]

--- a/grammars/blade.cson
+++ b/grammars/blade.cson
@@ -28,6 +28,9 @@
   'text.html.php.blade - (meta.embedded | meta.tag | comment.block.blade), L:(text.html.php.blade meta.tag - (comment.block.blade | meta.embedded.block.blade)), L:(source.js.embedded.html - (comment.block.blade | meta.embedded.block.blade))':
     'patterns': [
       {
+        'include': '#blade'
+      }
+      {
         'begin': '(^\\s*)(?=<\\?(?![^?]*\\?>))'
         'beginCaptures':
           '0':

--- a/grammars/blade.cson
+++ b/grammars/blade.cson
@@ -28,6 +28,104 @@
   'text.html.php.blade - (meta.embedded | meta.tag | comment.block.blade), L:(text.html.php.blade meta.tag - (comment.block.blade | meta.embedded.block.blade)), L:(source.js.embedded.html - (comment.block.blade | meta.embedded.block.blade))':
     'patterns': [
       {
+        'begin': '(^\\s*)(?=<\\?(?![^?]*\\?>))'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.whitespace.embedded.leading.php'
+        'end': '(?!\\G)(\\s*$\\n)?'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.whitespace.embedded.trailing.php'
+        'patterns': [
+          {
+            'begin': '<\\?(?i:php|=)?'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.begin.php'
+            'contentName': 'source.php'
+            'end': '(\\?)>'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'source.php'
+            'name': 'meta.embedded.block.php'
+            'patterns': [
+              {
+                'include': '#language'
+              }
+            ]
+          }
+        ]
+      }
+      {
+        'begin': '<\\?(?i:php|=)?(?![^?]*\\?>)'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+        'contentName': 'source.php'
+        'end': '(\\?)>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'source.php'
+        'name': 'meta.embedded.block.php'
+        'patterns': [
+          {
+            'include': '#language'
+          }
+        ]
+      }
+      {
+        'begin': '<\\?(?i:php|=)?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+        'end': '>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+        'name': 'meta.embedded.line.php'
+        'patterns': [
+          {
+            'captures':
+              '1':
+                'name': 'source.php'
+              '2':
+                'name': 'punctuation.section.embedded.end.php'
+              '3':
+                'name': 'source.php'
+            'match': '\\G(\\s*)((\\?))(?=>)'
+            'name': 'meta.special.empty-tag.php'
+          }
+          {
+            'begin': '\\G'
+            'contentName': 'source.php'
+            'end': '(\\?)(?=>)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'source.php'
+            'patterns': [
+              {
+                'include': '#language'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+'patterns': [
+  {
+    'include': 'text.html.basic'
+  }
+]
+'repository':
+  'blade':
+    'patterns': [
+      {
         # Comments
         'begin': '{{--'
         'beginCaptures':
@@ -482,103 +580,7 @@
                   \\b # Bounded by word boundary'''
         'name': 'entity.name.function.blade'
       }
-      # End of Blade specific code, followed by regular PHP grammar
-      {
-        'begin': '(^\\s*)(?=<\\?(?![^?]*\\?>))'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.whitespace.embedded.leading.php'
-        'end': '(?!\\G)(\\s*$\\n)?'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.whitespace.embedded.trailing.php'
-        'patterns': [
-          {
-            'begin': '<\\?(?i:php|=)?'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.begin.php'
-            'contentName': 'source.php'
-            'end': '(\\?)>'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'source.php'
-            'name': 'meta.embedded.block.php'
-            'patterns': [
-              {
-                'include': '#language'
-              }
-            ]
-          }
-        ]
-      }
-      {
-        'begin': '<\\?(?i:php|=)?(?![^?]*\\?>)'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-        'contentName': 'source.php'
-        'end': '(\\?)>'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-          '1':
-            'name': 'source.php'
-        'name': 'meta.embedded.block.php'
-        'patterns': [
-          {
-            'include': '#language'
-          }
-        ]
-      }
-      {
-        'begin': '<\\?(?i:php|=)?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.begin.php'
-        'end': '>'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.embedded.end.php'
-        'name': 'meta.embedded.line.php'
-        'patterns': [
-          {
-            'captures':
-              '1':
-                'name': 'source.php'
-              '2':
-                'name': 'punctuation.section.embedded.end.php'
-              '3':
-                'name': 'source.php'
-            'match': '\\G(\\s*)((\\?))(?=>)'
-            'name': 'meta.special.empty-tag.php'
-          }
-          {
-            'begin': '\\G'
-            'contentName': 'source.php'
-            'end': '(\\?)(?=>)'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.embedded.end.php'
-              '1':
-                'name': 'source.php'
-            'patterns': [
-              {
-                'include': '#language'
-              }
-            ]
-          }
-        ]
-      }
     ]
-'patterns': [
-  {
-    'include': 'text.html.basic'
-  }
-]
-'repository':
   'balance_brackets':
     'patterns': [
       {


### PR DESCRIPTION
Add support for hybrid [Blade/Markdown](https://jigsaw.tighten.co/docs/content-other-file-types/#blade/markdown-hybrids) syntax used by static site 
generators like Jigsaw.