### PR TITLE
Add another tab stop for section tag

### DIFF
--- a/snippets/language-blade.cson
+++ b/snippets/language-blade.cson
@@ -160,7 +160,7 @@
     'body': '''
               @section('${1:name}')
               \t$0
-              @endsection
+              @${2:endsection}
               '''
   "@stack('name')":
     'description': 'Renders contents of the stack.'


### PR DESCRIPTION
This is to accommodate cases where the user may wish to use `@show` instead of `@endsection` to immediately yield the section.