### PR TITLE
Add snippets for new component tags

### DIFF
--- a/snippets/language-blade.cson
+++ b/snippets/language-blade.cson
@@ -20,6 +20,24 @@
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#displaying-data'
     'prefix': 'raw'
     'body': '{!! ${1:$${2:message}} !!}$0'
+  '</x-component>':
+    'description': 'Generic component tag'
+    'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
+    'prefix': 'x'
+    'body': '<x-${1:component} ${2:${3:attribute}="${4:value}"}/>'
+  '<x-component> … </x-component>':
+    'description': 'Generic component tag with slot'
+    'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
+    'prefix': 'xx'
+    'body': '<x-${1:component} ${2:${3:attribute}="${4:value}"}>$0</x-${1:component}>'
+  '<x-component> … </x-component> (multiline)':
+    'description': 'Generic multiline component tag with slot'
+    'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
+    'prefix': 'xxx'
+    'body': """
+        <x-${1:component} ${2:${3:attribute}="${4:value}"}>
+        \t$0
+        </x-${1:component}>"""
   # Snippets without @ in prefix
   '@csrf':
     'description': 'Includes a CSRF field for use in forms.'

--- a/snippets/language-blade.cson
+++ b/snippets/language-blade.cson
@@ -30,7 +30,7 @@
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'xx'
     'body': """
-        <x-${1:component} ${2:${3:attribute}="${4:value}"}>${5:
+        <x-${1:component}${2: ${3:attribute}="${4:value}"}>${5:
         \t$0
         }</x-${1:component}>"""
   # Snippets without @ in prefix

--- a/snippets/language-blade.cson
+++ b/snippets/language-blade.cson
@@ -24,18 +24,18 @@
     'description': 'Generic component tag'
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'x'
-    'body': '<x-${1:component} ${2:${3:attribute}="${4:value}"}/>'
+    'body': '<x-${1:component}${2: ${3:attribute}="${4:value}"}/>'
   '<x-component> … </x-component>':
     'description': 'Generic component tag with slot'
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'xx'
-    'body': '<x-${1:component} ${2:${3:attribute}="${4:value}"}>$0</x-${1:component}>'
+    'body': '<x-${1:component}${2: ${3:attribute}="${4:value}"}>$0</x-${1:component}>'
   '<x-component> … </x-component> (multiline)':
     'description': 'Generic multiline component tag with slot'
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'xxx'
     'body': """
-        <x-${1:component} ${2:${3:attribute}="${4:value}"}>
+        <x-${1:component}${2: ${3:attribute}="${4:value}"}>
         \t$0
         </x-${1:component}>"""
   # Snippets without @ in prefix

--- a/snippets/language-blade.cson
+++ b/snippets/language-blade.cson
@@ -24,18 +24,18 @@
     'description': 'Generic component tag'
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'x'
-    'body': '<x-${1:component}${2: ${3:attribute}="${4:value}"}/>'
+    'body': '<x-${1:component} ${2:${3:attribute}="${4:value}"}/>'
   '<x-component> … </x-component>':
     'description': 'Generic component tag with slot'
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'xx'
-    'body': '<x-${1:component}${2: ${3:attribute}="${4:value}"}>$0</x-${1:component}>'
+    'body': '<x-${1:component} ${2:${3:attribute}="${4:value}"}>$0</x-${1:component}>'
   '<x-component> … </x-component> (multiline)':
     'description': 'Generic multiline component tag with slot'
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'xxx'
     'body': """
-        <x-${1:component}${2: ${3:attribute}="${4:value}"}>
+        <x-${1:component} ${2:${3:attribute}="${4:value}"}>
         \t$0
         </x-${1:component}>"""
   # Snippets without @ in prefix

--- a/snippets/language-blade.cson
+++ b/snippets/language-blade.cson
@@ -20,24 +20,19 @@
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#displaying-data'
     'prefix': 'raw'
     'body': '{!! ${1:$${2:message}} !!}$0'
-  '</x-component>':
+  '<x-component />':
     'description': 'Generic component tag'
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'x'
-    'body': '<x-${1:component} ${2:${3:attribute}="${4:value}"}/>'
+    'body': '<x-${1:component}${2: ${3:attribute}="${4:value}"} />$0'
   '<x-component> … </x-component>':
     'description': 'Generic component tag with slot'
     'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
     'prefix': 'xx'
-    'body': '<x-${1:component} ${2:${3:attribute}="${4:value}"}>$0</x-${1:component}>'
-  '<x-component> … </x-component> (multiline)':
-    'description': 'Generic multiline component tag with slot'
-    'descriptionMoreURL': 'https://laravel.com/docs/master/blade#components'
-    'prefix': 'xxx'
     'body': """
-        <x-${1:component} ${2:${3:attribute}="${4:value}"}>
+        <x-${1:component} ${2:${3:attribute}="${4:value}"}>${5:
         \t$0
-        </x-${1:component}>"""
+        }</x-${1:component}>"""
   # Snippets without @ in prefix
   '@csrf':
     'description': 'Includes a CSRF field for use in forms.'


### PR DESCRIPTION
This adds snippets for the new `<x-component>` tags.

Three new snippets are added:

- Simple component tag with no content
- Component tag with content
- Multi-line component tag

The prefixes I've used are `x`, `xx` and `xxx` respectively. I'm not sure if this conforms with the conventions used for the other snippets.
